### PR TITLE
Fix GitHub icon and footer alignment

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,15 +45,15 @@ export default function RootLayout({
     <html lang="en">
       <head />
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
-        <Theme appearance="dark">
-          <AuthKitProvider>
+        <AuthKitProvider>
+          <Theme appearance="dark" className="flex flex-col">
             <Navbar />
-            {children}
+            <main className="flex-grow">{children}</main>
             <Footer />
-          </AuthKitProvider>
-        </Theme>
+          </Theme>
+        </AuthKitProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 
 export default function Home() {
   return (
-    <div className="flex flex-col min-h-[calc(100vh-13vh)]">
+    <div className="flex flex-col">
       <main className="flex-1">
         <Suspense fallback={<div>Loading...</div>}>
           <ProductPage />

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -8,13 +8,6 @@ export default function Footer() {
       {/* Logo on the left */}
       <div className="flex items-center">
         <Link
-          href="https://github.com/workos/mcp.shop"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <FaGithub className="footer-social-icon w-5 h-5 text-neutral-400 transition" />
-        </Link>
-        <Link
           href="https://workos.com/?utm_source=mcp_shop&utm_medium=referral&utm_campaign=workos_mcp"
           target="_blank"
           rel="noopener noreferrer"
@@ -53,6 +46,13 @@ export default function Footer() {
           aria-label="YouTube"
         >
           <FaYoutube className="footer-social-icon w-5 h-5 text-neutral-400 transition" />
+        </Link>
+        <Link
+          href="https://github.com/workos/mcp.shop"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <FaGithub className="footer-social-icon w-5 h-5 text-neutral-400 transition" />
         </Link>
       </div>
     </footer>


### PR DESCRIPTION
Fixes some footer alignment, and moves the GitHub social icon to the right side with the others.

### Before

<img width="1114" height="226" alt="Screenshot 2025-08-01 at 11 40 13 AM" src="https://github.com/user-attachments/assets/5ff807b8-3101-44ce-a156-9db177bd526f" />

### After

<img width="1119" height="92" alt="Screenshot 2025-08-01 at 11 40 22 AM" src="https://github.com/user-attachments/assets/fb4eebb4-c392-40cb-a724-bd56d891d893" />
