### PR TITLE
Add search and fetch for ChatGPT support

### DIFF
--- a/app/[transport]/route.ts
+++ b/app/[transport]/route.ts
@@ -109,6 +109,7 @@ const handler = withAuthkit((request, auth) =>
         },
       );
 
+      // For ChatGPT support, a server must specifically support the search and fetch tools
       server.tool(
         "search",
         "Search for products available at mcp.shop. Returns a list of relevant products matching the search query.",

--- a/app/[transport]/route.ts
+++ b/app/[transport]/route.ts
@@ -108,6 +108,80 @@ const handler = withAuthkit((request, auth) =>
           }
         },
       );
+
+      server.tool(
+        "search",
+        "Search for products available at mcp.shop. Returns a list of relevant products matching the search query.",
+        {
+          query: z.string(),
+        },
+        async () => {
+          // Always return the shirt - it's the only product available
+          const results = [
+            {
+              id: "shirt",
+              title: "The MCP tee",
+            }
+          ];
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ results }),
+              },
+            ],
+          };
+        },
+      );
+
+      server.tool(
+        "fetch",
+        "Fetch detailed information about a specific product by its ID.",
+        {
+          id: z.string(),
+        },
+        async (args) => {
+          const { id } = args;
+          
+          if (id !== "shirt") {
+            throw new Error(`Product with ID "${id}" not found. Only "shirt" is available.`);
+          }
+
+          const result = {
+            id: "shirt",
+            title: "The MCP tee",
+            text: `Context is Everything
+
+Minimalist, mysterious, and maybe a little meta.
+
+This sleek tee features the MCP vibes and the phrase "Context is Everything". Whether you're a machine learning enthusiast, a protocol purist, or just someone who loves obscure tech references, this shirt delivers subtle nerd cred with style.
+
+Join the protocol. Set the context.
+
+Price: FREE
+Available: Yes (but slow delivery)
+
+Sizes: XS, S, M, L, XL, 2XL, 3XL
+
+To purchase this free shirt, you need to use a full-featured MCP client that supports tool use (like Claude Desktop, VS Code with MCP extension, or other MCP-compatible applications). The shirt cannot be purchased through this search interface alone.`,
+            metadata: {
+              price: "FREE",
+              requiresMcpClient: true,
+              availableSizes: ["XS", "S", "M", "L", "XL", "2XL", "3XL"]
+            },
+          };
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result),
+              },
+            ],
+          };
+        },
+      );
     },
     {
       // Optional server options


### PR DESCRIPTION
Simple additional of new tools to support ChatGPT to avoid any errors. These should be removed if ChatGPT no longer requires them.

We could also selectively show these tools based on the User Agent so they only show up for ChatGPT.