### PR TITLE
Fix broken VS Code Install badge

### DIFF
--- a/components/instructions.tsx
+++ b/components/instructions.tsx
@@ -163,6 +163,7 @@ export const Instructions = ({ openButtonLabel }: InstructionsProps) => {
                                   width={200}
                                   height={32}
                                   style={{ maxHeight: "32px", width: "auto" }}
+                                  unoptimized
                                 />
                               </a>
                             </div>


### PR DESCRIPTION
Since this image is coming back as an SVG, the Next.js image optimization pipeline rejects it for various reasons (the domain, the content type) documented [here](https://nextjs.org/docs/pages/api-reference/components/image#dangerouslyallowsvg).

We can instead add `unoptimized` (it's an SVG anyways), which fixes this.

## Before

<img width="929" height="312" alt="Screenshot 2025-11-19 at 9 28 17 AM" src="https://github.com/user-attachments/assets/b4ca58cc-fcfa-4c41-bb2c-f6df02e23d1a" />
<img width="718" height="588" alt="Screenshot 2025-11-19 at 9 28 05 AM" src="https://github.com/user-attachments/assets/f4bfb671-2ea8-4ff8-9175-efd5068c7a91" />

## After

<img width="796" height="668" alt="Screenshot 2025-11-19 at 9 27 42 AM" src="https://github.com/user-attachments/assets/1b5d1c58-2fc9-4fb5-aa3c-bb2750bf349f" />
