### PR TITLE
Correct MCP resource metadata path

### DIFF
--- a/app/[transport]/route.ts
+++ b/app/[transport]/route.ts
@@ -277,6 +277,7 @@ Thank you for trying out our MCP server!`,
 // Make authorization required — the verifyToken function is defined in lib/with-authkit.ts
 const authHandler = withMcpAuth(handler, verifyToken, {
   required: true,
+  resourceMetadataPath: "/.well-known/oauth-protected-resource/mcp",
 });
 
 export { authHandler as GET, authHandler as POST };


### PR DESCRIPTION
This should redirect MCP clients to https://mcp.shop/.well-known/oauth-protected-resource/mcp instead of http://mcp.shop/.well-known/oauth-protected-resource when they need to authorize. That, in turn, should allow the MCP clients to read from https://signin.mcp.shop/.well-known/oauth-authorization-server.